### PR TITLE
Update openai_client.py to not replace - with _ in tool names during …

### DIFF
--- a/src/chuk_llm/llm/providers/openai_client.py
+++ b/src/chuk_llm/llm/providers/openai_client.py
@@ -124,7 +124,7 @@ class OpenAILLMClient(ConfigAwareProviderMixin, OpenAIStyleMixin, BaseLLMClient)
                 original_name = func.get("name", "")
                 if original_name:
                     # Replace invalid characters with underscores
-                    sanitized_name = re.sub(r'[^a-zA-Z0-9_]', '_', original_name)
+                    sanitized_name = re.sub(r'[^a-zA-Z0-9_-]', '_', original_name)
                     # Ensure it starts with a letter or underscore
                     if sanitized_name and not sanitized_name[0].isalpha() and sanitized_name[0] != '_':
                         sanitized_name = '_' + sanitized_name


### PR DESCRIPTION
**Problem**
OpenAI-compliant tool names can contain `-` (dash) characters, but the tool name sanitation is incorrectly replacing `-` with underscore `_`.

**Reproduce**
Use an MCP server with long tool names that have `-` characters, such as IBM Cloud MCP Server with VPC plugin.

**Fix**
Update openai_client.py to not replace - with _ in tool names during sanitation.